### PR TITLE
Fix C# readme typo

### DIFF
--- a/Quickstart/00-Starter-Seed/README.md
+++ b/Quickstart/00-Starter-Seed/README.md
@@ -1,6 +1,6 @@
 # Login
 
-This example shows how to add ***Login/SignUp*** to your Windows Universal Platform application using the [Auth0 OIDC Client for .NET](https://github.com/auth0/auth0-oidc-client-net).
+This example shows how to use the Auth0 OIDC Client with a Windows UWP (Universal Windows Platform) C# application.
 
 You can read a quickstart for this sample [here](https://auth0.com/docs/quickstart/native/windows-uwp-csharp). 
 


### PR DESCRIPTION
Hi,

The readme currently links to the client for .NET, though it should be pertaining to C#. I didn't see a client like the one for .NET, so I just stated the purpose. If there should be a link, please let me know and I can change it. Thanks!

Closes: [https://github.com/auth0/docs/issues/5614](https://github.com/auth0/docs/issues/5614)